### PR TITLE
Clean up BrainFudger branding and language

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,26 @@
       "stopAtEntry": false
     },
     {
+      "name": "BrainFucker GUI",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build BrainFucker",
+      "program": "${workspaceFolder}/BrainFudger/bin/Debug/net10.0/BrainFucker.dll",
+      "cwd": "${workspaceFolder}",
+      "console": "internalConsole",
+      "stopAtEntry": false
+    },
+    {
+      "name": "BrainFux0r GUI",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build BrainFux0r",
+      "program": "${workspaceFolder}/BrainFudger/bin/Debug/net10.0/BrainFux0r.dll",
+      "cwd": "${workspaceFolder}",
+      "console": "internalConsole",
+      "stopAtEntry": false
+    },
+    {
       "name": "BrainFudger CLI Help",
       "type": "coreclr",
       "request": "launch",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -19,6 +19,38 @@
         "kind": "build",
         "isDefault": true
       }
+    },
+    {
+      "label": "build BrainFucker",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "build",
+        "${workspaceFolder}/BrainFudger/BrainFudger.csproj",
+        "-p:PublishAot=false",
+        "-p:BrandingDirective=IAMGARYPENN",
+        "-nologo"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "build BrainFux0r",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "build",
+        "${workspaceFolder}/BrainFudger/BrainFudger.csproj",
+        "-p:PublishAot=false",
+        "-p:BrandingDirective=ZEROCOOL",
+        "-nologo"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "problemMatcher": "$msCompile"
     }
   ]
 }

--- a/BrainFudger/BrainFudger.csproj
+++ b/BrainFudger/BrainFudger.csproj
@@ -12,6 +12,15 @@
     <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' and '$(PublishAot)' == 'true'">$(NETCoreSdkPortableRuntimeIdentifier)</RuntimeIdentifier>
     <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(BrandingDirective)' != ''">
+    <DefineConstants>$(DefineConstants);$(BrandingDirective)</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(BrandingDirective)' == 'IAMGARYPENN' or $([System.String]::Copy('$(DefineConstants)').Contains('IAMGARYPENN'))">
+    <AssemblyName>BrainFucker</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(BrandingDirective)' == 'ZEROCOOL' or $([System.String]::Copy('$(DefineConstants)').Contains('ZEROCOOL'))">
+    <AssemblyName>BrainFux0r</AssemblyName>
+  </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
     <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
   </PropertyGroup>

--- a/BrainFudger/Branding.cs
+++ b/BrainFudger/Branding.cs
@@ -1,0 +1,35 @@
+namespace BrainFudger;
+
+#if IAMGARYPENN && ZEROCOOL
+#error IAMGARYPENN and ZEROCOOL are mutually exclusive branding directives.
+#endif
+
+internal static class Branding
+{
+#if IAMGARYPENN
+    public const string AppDisplayName = "BrainFucker";
+    public const string CommandName = "brainfucker";
+    public const string LanguageDisplayName = "Brainfuck";
+    public const string LowercaseLanguageDisplayName = "brainfuck";
+#elif ZEROCOOL
+    public const string AppDisplayName = "BrainFux0r";
+    public const string CommandName = "brainfux0r";
+    public const string LanguageDisplayName = "BrainFux";
+    public const string LowercaseLanguageDisplayName = "brainfux";
+#else
+    public const string AppDisplayName = "BrainFudger";
+    public const string CommandName = "brainfudger";
+    public const string LanguageDisplayName = "Brainf$#k";
+    public const string LowercaseLanguageDisplayName = "brainf$#k";
+#endif
+
+    public static string SourceFileDescription => $"Path to the {LanguageDisplayName} source file.";
+
+    public static string SourceCompilationDescription => $"Compile {LanguageDisplayName} source into a native executable.";
+
+    public static string SourceCompilationProgress => $"Compiling {LowercaseLanguageDisplayName} source...";
+
+    public static string SourceFilePickerTitle => $"Select {LanguageDisplayName} source";
+
+    public static string SourceFileDialogFilter => $"{LanguageDisplayName} Source (*.bf)\0*.bf\0All Files (*.*)\0*.*\0\0";
+}

--- a/BrainFudger/Emitters/DosEmitter.cs
+++ b/BrainFudger/Emitters/DosEmitter.cs
@@ -26,8 +26,8 @@ internal sealed class MsDosComEmitter : IBinaryEmitter
 
     public byte[] EmitBinary(string sanitizedSource, CompilerOptions options)
     {
-        DosProgramImage program = DosBrainfuckEmitter.EmitProgramImage(sanitizedSource, options);
-        return DosBrainfuckEmitter.PatchAndFlatten(program.CodeImage, program.DataImage, ComOrigin);
+        DosProgramImage program = DosBrainFudgerEmitter.EmitProgramImage(sanitizedSource, options);
+        return DosBrainFudgerEmitter.PatchAndFlatten(program.CodeImage, program.DataImage, ComOrigin);
     }
 }
 
@@ -53,13 +53,13 @@ internal sealed class MsDosExeEmitter : IBinaryEmitter
 
     public byte[] EmitBinary(string sanitizedSource, CompilerOptions options)
     {
-        DosProgramImage program = DosBrainfuckEmitter.EmitProgramImage(sanitizedSource, options);
-        byte[] imageBytes = DosBrainfuckEmitter.PatchAndFlatten(program.CodeImage, program.DataImage, origin: 0);
+        DosProgramImage program = DosBrainFudgerEmitter.EmitProgramImage(sanitizedSource, options);
+        byte[] imageBytes = DosBrainFudgerEmitter.PatchAndFlatten(program.CodeImage, program.DataImage, origin: 0);
         return DosMzExecutableWriter.WriteExecutable(imageBytes, StackSize);
     }
 }
 
-internal static class DosBrainfuckEmitter
+internal static class DosBrainFudgerEmitter
 {
     public static DosProgramImage EmitProgramImage(string sanitizedSource, CompilerOptions options)
     {

--- a/BrainFudger/Gui/MacGuiApplication.cs
+++ b/BrainFudger/Gui/MacGuiApplication.cs
@@ -9,7 +9,6 @@ namespace BrainFudger;
 
 internal sealed class MacGuiApplication : IGuiApplicationHost
 {
-    private const string WindowTitle = "BrainFudger";
     private const nuint ActivationPolicyRegular = 0;
     private const nuint WindowStyleMaskTitled = 1;
     private const nuint WindowStyleMaskClosable = 2;
@@ -79,7 +78,7 @@ internal sealed class MacGuiApplication : IGuiApplicationHost
         }
         catch (Exception ex)
         {
-            ShowAlert("BrainFudger Mac GUI Failed", ex.Message, critical: true);
+            ShowAlert($"{Branding.AppDisplayName} Mac GUI Failed", ex.Message, critical: true);
             return 1;
         }
         finally
@@ -104,12 +103,12 @@ internal sealed class MacGuiApplication : IGuiApplicationHost
             BackingStoreBuffered,
             false);
 
-        Cocoa.SendVoid(_window, "setTitle:", Cocoa.ToNSString(WindowTitle));
+        Cocoa.SendVoid(_window, "setTitle:", Cocoa.ToNSString(Branding.AppDisplayName));
         Cocoa.SendVoid(_window, "center");
 
         nint contentView = Cocoa.SendIntPtr(_window, "contentView");
 
-        AddLabel(contentView, "Brainfuck source", new NSRect(20, 300, 140, 24));
+        AddLabel(contentView, $"{Branding.LanguageDisplayName} source", new NSRect(20, 300, 140, 24));
         _inputField = AddTextField(contentView, new NSRect(20, 270, 560, 28), editable: true);
         AddButton(contentView, "Browse…", new NSRect(600, 268, 120, 32), "browseInput:");
 
@@ -228,7 +227,7 @@ internal sealed class MacGuiApplication : IGuiApplicationHost
             string inputPath = GetControlText(_inputField).Trim();
             if (string.IsNullOrWhiteSpace(inputPath))
             {
-                ShowAlert("No source file selected", "Choose a Brainfuck source file first.", critical: false);
+                ShowAlert("No source file selected", $"Choose a {Branding.LanguageDisplayName} source file first.", critical: false);
                 return;
             }
 

--- a/BrainFudger/Gui/WindowsGuiApplication.cs
+++ b/BrainFudger/Gui/WindowsGuiApplication.cs
@@ -9,8 +9,6 @@ namespace BrainFudger.Gui;
 
 internal sealed class WindowsGuiApplication : IGuiApplicationHost
 {
-    private const string WindowClassName = "BrainFudgerWindowsGui";
-    private const string WindowTitle = "BrainFudger";
     private const uint WindowMessageBuildCompleted = NativeMethods.WM_APP + 1;
     private const string GuiHostArgument = "--gui-host";
 
@@ -48,6 +46,10 @@ internal sealed class WindowsGuiApplication : IGuiApplicationHost
 
     public static WindowsGuiApplication Instance { get; } = new();
 
+    private static string WindowClassName => $"{Branding.AppDisplayName}WindowsGui";
+
+    private static string WindowTitle => Branding.AppDisplayName;
+
     public bool TryHandleHostArguments(string[] args, out int exitCode)
     {
         if (args.Any(static arg => string.Equals(arg, GuiHostArgument, StringComparison.OrdinalIgnoreCase)))
@@ -69,11 +71,11 @@ internal sealed class WindowsGuiApplication : IGuiApplicationHost
     public int LaunchDetached()
     {
         string executablePath = Environment.ProcessPath
-            ?? throw new InvalidOperationException("Could not determine the BrainFudger executable path.");
+            ?? throw new InvalidOperationException($"Could not determine the {Branding.AppDisplayName} executable path.");
 
         if (!WindowsProcessHost.TryLaunchDetached(executablePath, GuiHostArgument, Environment.CurrentDirectory))
         {
-            throw new InvalidOperationException("Could not launch the BrainFudger GUI window.");
+            throw new InvalidOperationException($"Could not launch the {Branding.AppDisplayName} GUI window.");
         }
 
         return 0;
@@ -129,7 +131,7 @@ internal sealed class WindowsGuiApplication : IGuiApplicationHost
         ushort atom = NativeMethods.RegisterClassEx(ref windowClass);
         if (atom == 0)
         {
-            throw new InvalidOperationException("Failed to register the BrainFucker window class.");
+            throw new InvalidOperationException($"Failed to register the {Branding.AppDisplayName} window class.");
         }
 
         _windowHandle = NativeMethods.CreateWindowEx(
@@ -148,7 +150,7 @@ internal sealed class WindowsGuiApplication : IGuiApplicationHost
 
         if (_windowHandle == 0)
         {
-            throw new InvalidOperationException("Failed to create the BrainFucker window.");
+            throw new InvalidOperationException($"Failed to create the {Branding.AppDisplayName} window.");
         }
 
         NativeMethods.ShowWindow(_windowHandle, NativeMethods.SW_SHOW);
@@ -159,7 +161,7 @@ internal sealed class WindowsGuiApplication : IGuiApplicationHost
             int messageResult = NativeMethods.GetMessage(out Msg message, 0, 0, 0);
             if (messageResult == -1)
             {
-                throw new InvalidOperationException("The BrainFucker message loop terminated unexpectedly.");
+                throw new InvalidOperationException($"The {Branding.AppDisplayName} message loop terminated unexpectedly.");
             }
 
             if (messageResult == 0)
@@ -337,9 +339,9 @@ internal sealed class WindowsGuiApplication : IGuiApplicationHost
             StringBuilder pathBuilder = new(260);
             NativeMethods.DragQueryFile(dropHandle, 0, pathBuilder, (uint)pathBuilder.Capacity);
             string inputPath = pathBuilder.ToString();
-            if (!IsBrainfuckSourcePath(inputPath))
+            if (!IsSourceFilePath(inputPath))
             {
-                ShowWarning("Only .bf files can be dropped into the BrainFucker window.");
+                ShowWarning($"Only .bf files can be dropped into the {Branding.AppDisplayName} window.");
                 return;
             }
 
@@ -356,8 +358,8 @@ internal sealed class WindowsGuiApplication : IGuiApplicationHost
     private void BrowseForInput()
     {
         string? selectedFile = ShowOpenFileDialog(
-            title: "Select Brainfuck source",
-            filter: "Brainfuck Source (*.bf)\0*.bf\0All Files (*.*)\0*.*\0\0",
+            title: Branding.SourceFilePickerTitle,
+            filter: Branding.SourceFileDialogFilter,
             initialPath: GetControlText(_inputEditHandle));
 
         if (selectedFile is null)
@@ -399,7 +401,7 @@ internal sealed class WindowsGuiApplication : IGuiApplicationHost
             }
 
             string inputPath = GetControlText(_inputEditHandle).Trim();
-            if (!IsBrainfuckSourcePath(inputPath))
+            if (!IsSourceFilePath(inputPath))
             {
                 ShowWarning("Select a valid .bf source file before continuing.");
                 return;
@@ -614,7 +616,7 @@ internal sealed class WindowsGuiApplication : IGuiApplicationHost
         NativeMethods.MessageBox(_windowHandle, message, WindowTitle, NativeMethods.MB_ICONWARNING | NativeMethods.MB_OK);
     }
 
-    private static bool IsBrainfuckSourcePath(string path) =>
+    private static bool IsSourceFilePath(string path) =>
         !string.IsNullOrWhiteSpace(path)
         && string.Equals(Path.GetExtension(path), ".bf", StringComparison.OrdinalIgnoreCase);
 

--- a/BrainFudger/Models/CompilerOptions.cs
+++ b/BrainFudger/Models/CompilerOptions.cs
@@ -6,11 +6,7 @@ public sealed record CompilerOptions
     public string OutputPath { get; init; } = string.Empty;
     public bool OutputPathExplicit { get; init; }
     public int CellCount { get; init; } = 30000;
-#if WINDOWS
     public string Target { get; init; } = "win-x64";
-#elif APPLEOSX
-    public string Target { get; init; } = "osx-arm64";
-#endif
     public bool Run { get; init; }
     public bool QuietRun { get; init; }
     public bool UseShellExecuteForRun { get; init; }

--- a/BrainFudger/Program.cs
+++ b/BrainFudger/Program.cs
@@ -97,7 +97,7 @@ internal static class Program
     {
         Argument<FileInfo> inputArgument = new("input")
         {
-            Description = "Path to the Brainfuck source file."
+            Description = Branding.SourceFileDescription
         };
 
         Option<FileInfo?> outputOption = new("--output", "-o")
@@ -140,7 +140,7 @@ internal static class Program
             }
         });
 
-        RootCommand command = new("Compile Brainfuck source into a native executable.")
+        RootCommand command = new(Branding.SourceCompilationDescription)
         {
             inputArgument,
             outputOption,
@@ -199,7 +199,7 @@ internal static class Program
                 await AnsiConsole.Status()
                     .Spinner(Spinner.Known.Dots)
                     .SpinnerStyle(Style.Parse("deepskyblue2"))
-                    .StartAsync("Compiling brainfuck source...", async _ =>
+                    .StartAsync(Branding.SourceCompilationProgress, async _ =>
                     {
                         preparedCompilation = await CompilationWorkflow.PrepareAsync(options);
                     });
@@ -234,12 +234,12 @@ internal static class Program
             return;
         }
 
-        AnsiConsole.Write(new FigletText("BrainFudger").Color(Color.DeepSkyBlue2));
-        AnsiConsole.Write(new Markup("[grey]Compile Brainfuck source into a native executable.[/]\n\n"));
+        AnsiConsole.Write(new FigletText(Branding.AppDisplayName).Color(Color.DeepSkyBlue2));
+        AnsiConsole.Write(new Markup($"[grey]{Markup.Escape(Branding.SourceCompilationDescription)}[/]\n\n"));
 
         Table usage = new Table().Border(TableBorder.Rounded).AddColumn("[aqua]Usage[/]");
         usage.AddRow(
-            $"[white]brainfudger[/] [yellow]{Markup.Escape("<input.bf>")}[/] " +
+            $"[white]{Markup.Escape(Branding.CommandName)}[/] [yellow]{Markup.Escape("<input.bf>")}[/] " +
             $"[blue]{Markup.Escape("[-o output.exe|output.com|output]")}[/] " +
             $"[green]{Markup.Escape("[--run]")}[/] " +
             $"[grey]{Markup.Escape("[--quiet-run]")}[/] " +
@@ -250,7 +250,7 @@ internal static class Program
         AnsiConsole.WriteLine();
 
         Table options = new Table().RoundedBorder().AddColumns("[aqua]Option[/]", "[aqua]Description[/]");
-        options.AddRow("[yellow]<input>[/]", "Path to the Brainfuck source file.");
+        options.AddRow("[yellow]<input>[/]", Branding.SourceFileDescription);
 #if WINDOWS
         options.AddRow("[grey](no arguments)[/]", "Launch the native GUI file picker instead of the CLI error panel.");
 #endif
@@ -364,14 +364,14 @@ internal static class Program
 
     private static void RenderHelpPlainText()
     {
-        Console.WriteLine("BrainFudger");
-        Console.WriteLine("Compile Brainfuck source into a native executable.");
+        Console.WriteLine(Branding.AppDisplayName);
+        Console.WriteLine(Branding.SourceCompilationDescription);
         Console.WriteLine();
         Console.WriteLine("Usage:");
-        Console.WriteLine("  brainfudger <input.bf> [-o output.exe|output.com|output] [--run] [--quiet-run] [--list-targets] [--cells 30000] [--target win-x64|win-x86|msdos-com|msdos-exe|osx-arm64]");
+        Console.WriteLine($"  {Branding.CommandName} <input.bf> [-o output.exe|output.com|output] [--run] [--quiet-run] [--list-targets] [--cells 30000] [--target win-x64|win-x86|msdos-com|msdos-exe|osx-arm64]");
         Console.WriteLine();
         Console.WriteLine("Options:");
-        Console.WriteLine("  <input>           Path to the Brainfuck source file.");
+        Console.WriteLine($"  <input>           {Branding.SourceFileDescription}");
 #if WINDOWS || APPLEOSX
         Console.WriteLine("  (no arguments)    Launch the native GUI file picker instead of the CLI error panel.");
 #endif

--- a/BrainFudger/Services/BrainFudgerCompiler.cs
+++ b/BrainFudger/Services/BrainFudgerCompiler.cs
@@ -3,7 +3,7 @@ using BrainFudger.Models;
 
 namespace BrainFudger.Services;
 
-public static class BrainfuckCompiler
+public static class BrainFudgerCompiler
 {
     private static readonly HashSet<char> SignificantTokens = ['>', '<', '+', '-', '.', ',', '[', ']'];
 
@@ -29,7 +29,7 @@ public static class BrainfuckCompiler
                 case ']':
                     if (stack.Count == 0)
                     {
-                        throw new InvalidOperationException($"Unmatched closing bracket at Brainfuck instruction {i}.");
+                        throw new InvalidOperationException($"Unmatched closing bracket at {Branding.LanguageDisplayName} instruction {i}.");
                     }
 
                     stack.Pop();
@@ -39,7 +39,7 @@ public static class BrainfuckCompiler
 
         if (stack.Count > 0)
         {
-            throw new InvalidOperationException($"Unmatched opening bracket at Brainfuck instruction {stack.Peek()}.");
+            throw new InvalidOperationException($"Unmatched opening bracket at {Branding.LanguageDisplayName} instruction {stack.Peek()}.");
         }
     }
 }

--- a/BrainFudger/Services/CompilationWorkflow.cs
+++ b/BrainFudger/Services/CompilationWorkflow.cs
@@ -50,7 +50,7 @@ public static class CompilationWorkflow
         }
 
         string source = await File.ReadAllTextAsync(options.InputPath);
-        byte[] binary = BrainfuckCompiler.Compile(source, options, emitter);
+        byte[] binary = BrainFudgerCompiler.Compile(source, options, emitter);
         return new PreparedCompilation(options, emitter, binary);
     }
 
@@ -106,7 +106,7 @@ public static class CompilationWorkflow
 
     private static string CreateTemporaryOutputPath(string inputPath, string extension)
     {
-        string tempRoot = Path.Combine(Path.GetTempPath(), "BrainFudger");
+        string tempRoot = Path.Combine(Path.GetTempPath(), Branding.AppDisplayName);
         string tempDirectory = Path.Combine(tempRoot, Guid.NewGuid().ToString("N"));
         string fileName = Path.GetFileName(CreateDefaultOutputPath(inputPath, extension));
         return Path.Combine(tempDirectory, fileName);
@@ -198,7 +198,7 @@ public static class CompilationWorkflow
     {
         try
         {
-            string tempRoot = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "BrainFudger"));
+            string tempRoot = Path.GetFullPath(Path.Combine(Path.GetTempPath(), Branding.AppDisplayName));
             string fullDirectoryPath = Path.GetFullPath(directoryPath);
 
             if (!fullDirectoryPath.StartsWith(tempRoot + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # BrainFudger
 
-`BrainFudger` is a C# Brainfuck compiler with pluggable binary emitters. It currently ships with Win32 x64, Win32 x86, MS-DOS `.COM`, MS-DOS `MZ .EXE`, and macOS Apple Silicon Mach-O backends.
+`BrainFudger` is a C# Brainf$#k compiler with pluggable binary emitters. It currently ships with Win32 x64, Win32 x86, MS-DOS `.COM`, MS-DOS `MZ .EXE`, and macOS Apple Silicon Mach-O backends.
 
-If you want the full hex-goblin tour, the new [docs index](./docs/README.md) walks through Brainfuck itself plus the executable formats this project emits.
-
-The app stays as a single project, with compiler-gated platform GUI hosts:
+If you want the full hex-goblin tour, the new [docs index](./docs/README.md) walks through Brainf$#k itself plus the executable formats this project emits.
 
 - the CLI remains the default interactive surface
 - a native Win32 GUI host is compiled in on Windows
@@ -12,7 +10,7 @@ The app stays as a single project, with compiler-gated platform GUI hosts:
 
 ## What it does
 
-- reads a Brainfuck source file
+- reads a Brainf$#k source file
 - validates matching loop brackets
 - generates a valid native executable
 - generates tape bounds checks so invalid pointer moves fail with an error
@@ -57,22 +55,15 @@ To publish:
 dotnet publish -c Release
 ```
 
-## Releases
+Alternate branding builds:
 
-Release notes live in [docs/releasing.md](./docs/releasing.md).
+```powershell
+dotnet build -p:BrandingDirective=IAMGARYPENN
+```
 
-Short version:
-
-- use semantic tags like `v1.2.3`, `v1.3.0-alpha.1`, or `v2.0.0-rc.1`
-- only `v*` tags trigger the GitHub release workflow
-- `bugfix` bumps patch, `feature` bumps minor, `breaking` bumps major
-- prerelease tags become GitHub prereleases automatically
-- release builds include commit-count and short-SHA metadata in `InformationalVersion`
-- use the **Cut Release Tag** workflow in GitHub Actions to calculate and push the next tag
-
-When built on Windows, MSBuild defines the GUI compile symbol automatically, so launching `BrainFudger.exe` without parameters opens the native file-picker GUI. Parameterized launches continue to use the CLI.
-
-On macOS, the AppKit host provides a native window with source/output pickers, target selection, cells input, and Build/Run buttons wired through the same compilation workflow as the CLI.
+```powershell
+dotnet build -p:BrandingDirective=ZEROCOOL
+```
 
 ## Options
 
@@ -108,3 +99,14 @@ The `osx-arm64` target emits a 64-bit Mach-O executable for Apple Silicon Macs.
 - the generated file defaults to no extension, but you can still provide any output name you like
 - future work will likely add `osx-x64` and a universal/fat binary wrapper
 - See [docs/mach-o-arm64.md](./docs/mach-o-arm64.md) for the low-level format breakdown
+
+## The Elephant
+
+Yes, this is the part where a professional developer admits the README had an elephant in it.
+
+The default build ships with censored public-facing wording. If you want to uncensor it at compile time, there are two opt-in switches:
+
+- `ZEROCOOL`: swaps the public branding to `BrainFux0r` and the language name to `BrainFux`
+- `IAMGARYPENN`: removes all censoring on the branding, and refers to the language by its official name. Extra points if you get the reference. If you google it, you did not get the reference.
+
+Do not enable both at once.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,12 +4,12 @@ Welcome to the cursed library.
 
 This folder has two jobs:
 
-1. explain Brainfuck itself clearly enough that somebody can read or write it without vibes-only guessing
+1. explain Brainf$#k itself clearly enough that somebody can read or write it without vibes-only guessing
 2. explain the executable formats BrainFudger emits well enough that you could hand-craft a working binary with a hex editor, patience, and the correct amount of spite
 
 ## Reading Order
 
-- [Brainfuck Language](./brainfuck-language.md): syntax, semantics, I/O, common idioms, and practical gotchas
+- [Brainf$#k Language](./brainf$#k-language.md): syntax, semantics, I/O, common idioms, and practical gotchas
 - [Executable Fundamentals](./executable-fundamentals.md): the general mental model for turning bytes into runnable programs
 - [PE32 for Win x86](./pe32-x86.md): 32-bit Windows executables
 - [PE32+ for Win x64](./pe32-plus-x64.md): 64-bit Windows executables
@@ -28,7 +28,7 @@ If you want to craft an executable by hand, you need to think in layers:
 - loader expectations
 - OS services for I/O, process exit, and imports
 
-That stack is the whole game. BrainFudger happens to automate it for Brainfuck, but the docs are written to be useful even if your payload is not Brainfuck at all.
+That stack is the whole game. BrainFudger happens to automate it for Brainf$#k, but the docs are written to be useful even if your payload is not Brainf$#k at all.
 
 ## Format Coverage
 

--- a/docs/TARGETS.md
+++ b/docs/TARGETS.md
@@ -159,7 +159,7 @@ This document tracks current targets and planned expansions, primarily focused o
 
 ## End Goal
 
-A Brainfuck compiler capable of targeting executable formats across the historical spectrum of the DOS/Windows ecosystem, including:
+A Brainf$#k compiler capable of targeting executable formats across the historical spectrum of the DOS/Windows ecosystem, including:
 
 - real mode
 - protected mode

--- a/docs/brainf$#k-language.md
+++ b/docs/brainf$#k-language.md
@@ -1,12 +1,12 @@
-# Brainfuck Language Guide 🧠➡️⬅️➕➖
+# Brainf$#k Language Guide 🧠➡️⬅️➕➖
 
-Brainfuck is tiny, hostile, and surprisingly teachable once you stop expecting it to be polite.
+Brainf$#k is tiny, hostile, and surprisingly teachable once you stop expecting it to be polite.
 
 This document covers the language itself, independent of any binary format.
 
 ## Core Model
 
-A Brainfuck program operates on:
+A Brainf$#k program operates on:
 
 - a tape of cells
 - a data pointer that points at the current cell
@@ -20,7 +20,7 @@ In the classic model:
 - arithmetic wraps modulo 256
 - the tape is conceptually unbounded
 
-In BrainFudger's generated binaries:
+In the generated binaries described here:
 
 - cells are 8-bit bytes
 - arithmetic wraps naturally because the emitted instructions modify bytes
@@ -29,7 +29,7 @@ In BrainFudger's generated binaries:
 
 ## The Eight Instructions
 
-Everything else in a Brainfuck source file is comment noise.
+Everything else in a Brainf$#k source file is comment noise.
 
 | Token | Meaning |
 | --- | --- |
@@ -44,7 +44,7 @@ Everything else in a Brainfuck source file is comment noise.
 
 ## Operational Semantics
 
-You can think of Brainfuck as this little machine:
+You can think of Brainf$#k as this little machine:
 
 ```text
 state = {
@@ -67,7 +67,7 @@ Instruction behavior:
 
 ## Input Semantics
 
-This is where Brainfuck implementations become little goblins.
+This is where Brainf$#k implementations become little goblins.
 
 The original language did not standardize EOF behavior. Common choices are:
 
@@ -76,7 +76,7 @@ The original language did not standardize EOF behavior. Common choices are:
 - store `255`
 - signal an error
 
-BrainFudger's emitted binaries do this:
+The emitted binaries described here do this:
 
 - attempt to read one byte
 - if the read fails or reaches EOF, store `0` in the current cell
@@ -85,13 +85,13 @@ That makes programs deterministic across the currently supported targets.
 
 ## Comments And Ignored Characters
 
-Brainfuck only cares about these eight tokens:
+Brainf$#k only cares about these eight tokens:
 
 ```text
 ><+-.,[]
 ```
 
-Everything else is ignored. BrainFudger sanitizes the source by stripping everything except the eight significant tokens before validation or code generation.
+Everything else is ignored. The compiler frontend sanitizes the source by stripping everything except the eight significant tokens before validation or code generation.
 
 ## Loop Matching
 
@@ -111,13 +111,13 @@ That is exactly the strategy used in the compiler frontend.
 
 ### Clear A Cell
 
-```brainfuck
+```text
 [-]
 ```
 
 ### Move A Value Right
 
-```brainfuck
+```text
 [->+<]
 ```
 
@@ -125,15 +125,15 @@ That is exactly the strategy used in the compiler frontend.
 
 Typical copy requires a scratch cell:
 
-```brainfuck
+```text
 [->+>+<<]>>[-<<+>>]
 ```
 
 ### Emit ASCII Text
 
-Brainfuck string literals are usually done by building ASCII values in cells and printing them:
+Brainf$#k string literals are usually done by building ASCII values in cells and printing them:
 
-```brainfuck
+```text
 +++++++++[>+++++++>++++++++++>+++>+<<<<-]
 >++.
 >+.
@@ -148,11 +148,11 @@ Brainfuck string literals are usually done by building ASCII values in cells and
 
 Compilers often compress runs like:
 
-```brainfuck
+```text
 +++++++++
 ```
 
-into a single "add 10" operation. BrainFudger does this for:
+into a single "add 10" operation. The compiler described here does this for:
 
 - `+`
 - `-`
@@ -161,7 +161,7 @@ into a single "add 10" operation. BrainFudger does this for:
 
 ### Tape Bounds
 
-Pure Brainfuck pretends the tape goes on forever. BrainFudger allocates a fixed tape and inserts bounds checks:
+Pure Brainf$#k pretends the tape goes on forever. The implementation described here allocates a fixed tape and inserts bounds checks:
 
 - moving left of the first cell prints an error and exits
 - moving right at or past the end prints an error and exits
@@ -188,14 +188,14 @@ while pc < source.length:
   pc++
 ```
 
-## Hand-Compiling Brainfuck To Machine Code
+## Hand-Compiling Brainf$#k To Machine Code
 
 General recipe:
 
 1. choose where the tape lives
 2. dedicate one register to the current cell pointer
 3. dedicate one or two registers to tape bounds if you need safety checks
-4. translate each Brainfuck token into machine instructions
+4. translate each Brainf$#k token into machine instructions
 5. patch loop jumps once labels are known
 6. add OS-specific output, input, and exit routines
 7. wrap the resulting code in an executable container
@@ -209,4 +209,4 @@ That last step is where the format-specific docs take over.
 - tape length is implementation-defined
 - pointer underflow and overflow behavior is implementation-defined
 
-If you are writing Brainfuck that must run on many implementations, avoid relying on anything except the eight core instruction meanings.
+If you are writing Brainf$#k that must run on many implementations, avoid relying on anything except the eight core instruction meanings.

--- a/docs/mach-o-arm64.md
+++ b/docs/mach-o-arm64.md
@@ -137,7 +137,7 @@ Standard descriptors are the usual Unix ones:
 
 The data section contains:
 
-- the Brainfuck tape
+- the Brainf$#k tape
 - `tape_end`
 - pointer-before-start message
 - pointer-past-end message
@@ -205,9 +205,9 @@ otool -l ./hello
 
 If `otool` complains about inconsistent command sizes or segment math, fix the file first. Code signing cannot save a binary whose structure is already wrong.
 
-## Why This Matters Beyond Brainfuck
+## Why This Matters Beyond Brainf$#k
 
-None of this is Brainfuck-specific. Swap the payload out for any other ARM64 code and the container rules stay the same:
+None of this is Brainf$#k-specific. Swap the payload out for any other ARM64 code and the container rules stay the same:
 
 - identify the file correctly
 - describe the mapped image coherently

--- a/docs/msdos-com.md
+++ b/docs/msdos-com.md
@@ -82,7 +82,7 @@ DL = character
 INT 21h
 ```
 
-BrainFudger uses this for Brainfuck `.`.
+BrainFudger uses this for Brainf$#k `.`.
 
 ### Read One Byte From Standard Input
 
@@ -99,7 +99,7 @@ On return:
 - `AX` = bytes read
 - `AX = 0` means EOF
 
-BrainFudger uses this for Brainfuck `,` and zeroes the current cell on EOF.
+BrainFudger uses this for Brainf$#k `,` and zeroes the current cell on EOF.
 
 ### Print A `$`-Terminated String
 

--- a/docs/msdos-mz-exe.md
+++ b/docs/msdos-mz-exe.md
@@ -88,9 +88,9 @@ BrainFudger's current `msdos-exe` writer does not emit relocations and instead k
 
 ## Shared Payload With `.COM`
 
-The DOS `.EXE` target reuses the same Brainfuck code and data generation logic as the `.COM` target:
+The DOS `.EXE` target reuses the same Brainf$#k code and data generation logic as the `.COM` target:
 
-- same Brainfuck lowering
+- same Brainf$#k lowering
 - same DOS interrupt services
 - same data strings
 - same patching model for label references

--- a/docs/pe32-plus-x64.md
+++ b/docs/pe32-plus-x64.md
@@ -121,7 +121,7 @@ The startup flow is:
 2. call `GetStdHandle` for stdin, stdout, and stderr
 3. store those handles in preserved registers
 4. load tape start and tape end with RIP-relative `lea`
-5. execute translated Brainfuck
+5. execute translated Brainf$#k
 6. call `ExitProcess(0)`
 
 ## Patch Math

--- a/docs/pe32-x86.md
+++ b/docs/pe32-x86.md
@@ -75,7 +75,7 @@ Contains:
 
 - process startup
 - `GetStdHandle` calls
-- Brainfuck translation
+- Brainf$#k translation
 - error handling paths
 - exit path
 
@@ -140,7 +140,7 @@ The emitted program does:
    - `EBX` = current tape cell
    - `ESI` = tape start
    - `EDI` = tape end
-4. emit translated Brainfuck operations
+4. emit translated Brainf$#k operations
 5. call `ExitProcess`
 
 ### I/O Calls
@@ -226,4 +226,4 @@ Workflow:
 - broken branch displacement
 - section raw pointers not aligned to `0x200`
 
-None of this is Brainfuck-specific. Replace the payload and the PE container rules stay the same.
+None of this is Brainf$#k-specific. Replace the payload and the PE container rules stay the same.


### PR DESCRIPTION
## Summary

This updates the default build to ship as `BrainFudger`, censors default public-facing language references to `BrainF$#k` where appropriate, and keeps the joke branding modes available behind compile-time switches.

## What changed

- centralized branding strings in a shared helper
- renamed the default compiler/frontend identifiers away from uncensored language
- added compile-time branding modes for `IAMGARYPENN` and `ZEROCOOL`
- cleaned up README and docs wording outside `.bf` source files
- renamed the language guide to `docs/brainf$#k-language.md`
- added VS Code build/launch targets for GUI testing of the alternate branding builds

## Validation

- `dotnet build .\BrainFudger\BrainFudger.csproj -p:PublishAot=false -nologo`
- `dotnet build .\BrainFudger\BrainFudger.csproj -p:PublishAot=false -p:BrandingDirective=IAMGARYPENN -nologo`
- `dotnet build .\BrainFudger\BrainFudger.csproj -p:PublishAot=false -p:BrandingDirective=ZEROCOOL -nologo`

Closes #6